### PR TITLE
Improve support for back ticks

### DIFF
--- a/markupParser/Text/Udoc/DocumentParser.hs
+++ b/markupParser/Text/Udoc/DocumentParser.hs
@@ -515,6 +515,7 @@ wordChar = do
             <|> (try $ escaped '}')
             <|> (try $ escaped '"')
             <|> (try $ escaped '\\')
+            <|> (try $ escaped '`')
             <|> (noneOf $ " \t\n[]|{}\"" ++ additional)
             <?> "a valid word character"
    
@@ -545,7 +546,7 @@ verbatimBold closingTag = do
 verbatimText :: String -> IParse DocumentItem
 verbatimText closingTag = do 
    result <- many1 (wordChar 
-                    <|> oneOf "\n\t |{}\"]"
+                    <|> oneOf "\n\t |{}\"]`"
                     <|> ( (notFollowedBy $ string closingTag) >>
                           (notFollowedBy $ string "[b]") >>
                           (notFollowedBy $ string "[/b]") >>


### PR DESCRIPTION
Currently back ticks are not escable and can't get used inside [quote] or [source] without crashing the compiler. This should be fixed by this merge request.

