### PR TITLE
Crash on empty line after block quote

### DIFF
--- a/markupParser/Text/Udoc/DocumentParser.hs
+++ b/markupParser/Text/Udoc/DocumentParser.hs
@@ -756,6 +756,7 @@ blockQuote = do
        thisLine <- many $ noneOf "\n"
        optional newline
        return thisLine
+    skipEmptyLines
     return $ ItemDocumentContainer $ DocumentMetaContainer [("type","blockquote")] [ItemWord $ intercalate "\n" lines]
 
 -- | The start of a fenced code block


### PR DESCRIPTION
The parser crashes if an empty line follows on a block quote. The reason is that the definition of block quote misses to consume the empty lines and therefore expects an end of input afterwards but this exception fails as soon as next non empty line is encountered.