### PR TITLE
[Parser] Removes most of the escaping inside the verbatim elements [source] and [quote].

### DIFF
--- a/markupParser/Text/Udoc/DocumentParser.hs
+++ b/markupParser/Text/Udoc/DocumentParser.hs
@@ -544,15 +544,25 @@ verbatimBold closingTag = do
 -- we handle [b] and [/b], in order to allow for bold parts in source
 -- code.
 verbatimText :: String -> IParse DocumentItem
-verbatimText closingTag = do 
-   result <- many1 (wordChar 
-                    <|> oneOf "\n\t |{}\"]`"
-                    <|> ( (notFollowedBy $ string closingTag) >>
-                          (notFollowedBy $ string "[b]") >>
-                          (notFollowedBy $ string "[/b]") >>
-                          (char '[')
-                        )
-                    )
+verbatimText closingTag = do
+   result <- many1 (
+                      (
+                         (
+                              (try $ lookAhead $ string "\\[b]")
+                              <|> (try $ lookAhead $ string "\\[/b]")
+                              <|> (try $ lookAhead $ string $ "\\" ++ closingTag)
+                         ) >>
+                         (escaped '[')
+                      )
+                      <|>
+                      (
+                         (notFollowedBy $ string closingTag) >>
+                         (notFollowedBy $ string "[b]") >>
+                         (notFollowedBy $ string "[/b]") >>
+                         (anyChar)
+                      )
+                   )
+
    return $ ItemWord result
 
 -- | Contents of the inline verbatim container - may basically be everything


### PR DESCRIPTION
This patch removes all of the `\` based special character escaping
methods inside the verbatim containers.

Exceptions from this rule are the escaped bold tags `\[b]`, `\[/b]`
and depending on the current container either `\[/source]` or `\[/quote]`.

These exceptions are necessary to ensure that while bold formatting is still
possible inside verbatim containers while the related tags can still be mentioned
inside the container content. The same applies to the expected closing tag.