### PR TITLE
[Renderer] Improves the smart space pre render hook to avoid spaces at the start of a paragraph.

### DIFF
--- a/OpenOfficeIntegration/Renderer/Renderer.py
+++ b/OpenOfficeIntegration/Renderer/Renderer.py
@@ -235,7 +235,10 @@ class Renderer(object):
                return True
          return False
       def fun(item):
-         if self._isWord(item) and not startsWithPunctation(self._getWord(item)):
+         if self._isWord(item) \
+               and not startsWithPunctation(self._getWord(item)) \
+               and not self._cursor.isStartOfParagraph():
+
             self.insertString(' ')
          return True
       self._hookRender = fun


### PR DESCRIPTION
This is necessary as it can happen that the hook is still present directly after a paragraph break which automatically inserts a space in front of the leading word if its not further wrapped into some kind of container.

Most likely just a workaround for a parser issue in custom meta tags but still worth as it just improves the smart space logic.