### PR TITLE
fix/issues to allow haskell js conversion

### DIFF
--- a/markupParser/Text/Udoc/DocumentParser.hs
+++ b/markupParser/Text/Udoc/DocumentParser.hs
@@ -29,8 +29,6 @@ import qualified Text.Parsec.Prim as PP
 import           Control.Monad
 import           Control.Monad.State
 import           Text.JSON
---import           Data.Either
---import           Data.Either.Utils
 import           Text.Udoc.Document
 import           Data.Maybe
 import           Data.Functor.Identity

--- a/markupParser/Text/Udoc/DocumentParser.hs
+++ b/markupParser/Text/Udoc/DocumentParser.hs
@@ -29,8 +29,8 @@ import qualified Text.Parsec.Prim as PP
 import           Control.Monad
 import           Control.Monad.State
 import           Text.JSON
-import           Data.Either
-import           Data.Either.Utils
+--import           Data.Either
+--import           Data.Either.Utils
 import           Text.Udoc.Document
 import           Data.Maybe
 import           Data.Functor.Identity

--- a/markupParser/markupParser.cabal
+++ b/markupParser/markupParser.cabal
@@ -21,7 +21,6 @@ library
                        , parsec >=3.1
                        , mtl >=2.1
                        , json >=0.7
-                       --, MissingH >=1.2
                        , transformers >=0.3
                        , indents >=0.3 && < 0.4
 
@@ -32,7 +31,6 @@ Executable parseUdoc
                      , parsec >=3.1
                      , mtl >=2.1
                      , json >=0.7
-                     --, MissingH >=1.2
                      , transformers >=0.3
                      , indents >=0.3 && < 0.4
                      , markupParser

--- a/markupParser/markupParser.cabal
+++ b/markupParser/markupParser.cabal
@@ -21,17 +21,18 @@ library
                        , parsec >=3.1
                        , mtl >=2.1
                        , json >=0.7
-                       , MissingH >=1.2
+                       --, MissingH >=1.2
                        , transformers >=0.3
                        , indents >=0.3 && < 0.4
 
 Executable parseUdoc
   Main-is:           parseUdoc.hs
+  other-modules:     Text.Udoc.Document, Text.Udoc.DocumentParser
   Build-Depends:       base
                      , parsec >=3.1
                      , mtl >=2.1
                      , json >=0.7
-                     , MissingH >=1.2
+                     --, MissingH >=1.2
                      , transformers >=0.3
                      , indents >=0.3 && < 0.4
                      , markupParser


### PR DESCRIPTION
Removes some unused imports and adds two missing module references into the cabal file. This was necessary as a tool for haskell to js conversion complained about it