### PR TITLE
[Renderer] Break paragraph on pagebreak.

### DIFF
--- a/OpenOfficeIntegration/Renderer/Renderer.py
+++ b/OpenOfficeIntegration/Renderer/Renderer.py
@@ -621,7 +621,8 @@ class Renderer(object):
       self.doAfterRendering(updateToc)
 
    def insertPageBreak(self):
-      self._cursor.gotoEnd(False)      
+      self.insert_paragraph_character(avoid_empty_paragraph=True)
+      self._cursor.gotoEnd(False)
       self._cursor.BreakType = PAGE_BEFORE
 
    def insertTable(self, tableContent, caption, labelName, style, widths):
@@ -757,8 +758,10 @@ class Renderer(object):
       self.insert_paragraph_character(avoid_empty_paragraph=True)
 
    def insert_paragraph_character(self, avoid_empty_paragraph=True):
-       if avoid_empty_paragraph and not self._cursor.isStartOfParagraph():
-           self._document.Text.insertControlCharacter(self._cursor, PARAGRAPH_BREAK, False)
+       if not avoid_empty_paragraph \
+          or not self._cursor.isStartOfParagraph():
+
+          self._document.Text.insertControlCharacter(self._cursor, PARAGRAPH_BREAK, False)
 
    def template_width(self):
        """


### PR DESCRIPTION
As a page break is always applied to the current active paragraph, this change is necessary to ensure that the break always appears at the requested position inside the document and not before or after the current active paragraph. This mimics the behavior of libreoffice.