### PR TITLE
[Renderer] Fix/avoid space between inline source and word ending

### DIFF
--- a/OpenOfficeIntegration/Renderer/Renderer.py
+++ b/OpenOfficeIntegration/Renderer/Renderer.py
@@ -240,7 +240,7 @@ class Renderer(object):
             return item['ItemWord']
       return None
 
-   def smartSpace(self, split_ending=True):
+   def smartSpace(self, skip_if=lambda cursor, word: cursor.isStartOfParagraph()):
       punctuation = ('.', ',', ';', ':', '!', '?', ')', ']')
 
       def starts_with_punctuation(word):
@@ -255,8 +255,7 @@ class Renderer(object):
 
          if self._isWord(word)\
             and not starts_with_punctuation(word)\
-            and not self._cursor.isStartOfParagraph()\
-            and (split_ending or word != "s"):
+            and not (skip_if and skip_if(self._cursor, word)):
 
             self.insertString(' ')
 
@@ -560,7 +559,7 @@ class Renderer(object):
          refName = 'X' + refName
       self.knownImageRefs.append(refName)
       self.insertBookmark(refName)
-      self.smartSpace()
+      self.smartSpace(skip_if=lambda _cursor, _word: False)
 
       space = self.needSpace()
       def do_insert_imageref(self):
@@ -592,7 +591,7 @@ class Renderer(object):
          refName = 'X' + refName
       self.knownTableRefs.append(refName)
       self.insertBookmark(refName)
-      self.smartSpace()
+      self.smartSpace(skip_if=lambda _cursor, _word: False)
 
       space = self.needSpace()
       def do_insert_tableref(self):
@@ -758,7 +757,7 @@ class Renderer(object):
 
       old_name = self.changeCharProperty(CharProp.StyleName, self.STYLE_INLINE_SOURCE_CODE)
       self.render(text)
-      self.smartSpace(split_ending=False)
+      self.smartSpace(skip_if=lambda _cursor, word: word == "s")
       self.changeCharProperty(CharProp.StyleName, old_name)
 
    def insertParagraph(self, text):

--- a/OpenOfficeIntegration/Renderer/Renderer.py
+++ b/OpenOfficeIntegration/Renderer/Renderer.py
@@ -252,16 +252,15 @@ class Renderer(object):
 
       def smart_space_hook(item):
          word = self._getWord(item)
-         if not split_ending and word == "s":
-            return True
 
-         if not self._isWord(word)\
-            or starts_with_punctuation(word)\
-            or self._cursor.isStartOfParagraph():
+         if self._isWord(word)\
+            and not starts_with_punctuation(word)\
+            and not self._cursor.isStartOfParagraph()\
+            and (split_ending or word != "s"):
 
-            return True
+            self.insertString(' ')
 
-         self.insertString(' ')
+         return True
 
       self._hookRender = smart_space_hook
 


### PR DESCRIPTION
Refactors the check for `isStartOfParagraph` in `smartSpace` into a custom user definable callback to allow us to add special conditions in which an additional space is (dis)allowed.

**Also introduces three custom checks:**

(1) & (2) ensure that any element rendered after an image or table reference is separated by a space from the previous reference.

(3) Introduces a special case for inline source which is followed by a single `s` to ignore the space and merge the content as we would to it if the word starts with punctuation.  This could be extended to include other cases as well based on the documentation language. I know that this is more a dirty workaround than an actual solution but as long as we do not introduce  methods which change the rendering style based on the current language I couldn't come up with a better solution.