### PR TITLE
[Renderer] Avoid to request a space if the previous word item ends with '['.

### DIFF
--- a/OpenOfficeIntegration/Renderer/Renderer.py
+++ b/OpenOfficeIntegration/Renderer/Renderer.py
@@ -276,7 +276,7 @@ class Renderer(object):
    def needSpace(self):
       w = self._getWord(self._lastItem)
       if w is not None:
-         return not w.endswith('(')
+         return not (w.endswith('(') or w.endswith('['))
 
       type_name = self._get_meta_tag_type(self._lastItem)
       if type_name not in ["footnote", "imgref", "inlineimage", "ref", "tblref"]:


### PR DESCRIPTION
If the renderer doesn't request a space in case of a leading `(` it shouldn't request one in case of `[`. This might be necessary as references and other things sometimes also appear inside brackets instead of parentheses.

Unsure if this might also is true for `{` and `<`.