### PR TITLE
[Renderer] Avoid space after inline source on paragraph end.

### DIFF
--- a/OpenOfficeIntegration/Renderer/Renderer.py
+++ b/OpenOfficeIntegration/Renderer/Renderer.py
@@ -782,7 +782,7 @@ class Renderer(object):
 
       old_name = self.changeCharProperty(CharProp.StyleName, self.STYLE_INLINE_SOURCE_CODE)
       self.render(text)
-      self.smartSpace(skip_if=lambda _cursor, word: word == "s")
+      self.smartSpace(skip_if=lambda cursor, word: word == "s" or cursor.isStartOfParagraph())
       self.changeCharProperty(CharProp.StyleName, old_name)
 
    def insertParagraph(self, text):


### PR DESCRIPTION
The old rendering hook adds a new space at the beginning of a new
paragraph if the previous one ended with some inline source code.

Reason was a missing check if the next word is at the beginning
of a new paragraph inside the custom `skip_if` lambda inside the
method which handles inline source insertion.