### PR TITLE
[Parser|Renderer] Introduce italic support.

### DIFF
--- a/OpenOfficeIntegration/Renderer/Renderer.py
+++ b/OpenOfficeIntegration/Renderer/Renderer.py
@@ -14,6 +14,7 @@ import json
 import platform
 import time
 
+from com.sun.star.awt.FontSlant import ITALIC, NONE
 from com.sun.star.awt.FontWeight import BOLD, NORMAL
 from com.sun.star.lang import Locale
 from com.sun.star.style.BreakType import PAGE_AFTER,PAGE_BEFORE
@@ -107,6 +108,13 @@ class Renderer(object):
       if not self._inSource:
           self.smartSpace()
 
+   def renderItalicFace(self, items):
+      if self.needSpace():
+         self.insertString(' ')
+
+      self.insertItalicFace(items)
+      self.smartSpace()
+
    def renderParagraph(self, items):
       self.insertParagraph(items)
 
@@ -185,6 +193,8 @@ class Renderer(object):
                             container['content'])
       elif containerType == 'DocumentBoldFace':
          self.renderBoldFace(container['content'])
+      elif containerType == 'DocumentItalicFace':
+         self.renderItalicFace(container['content'])
       elif containerType == 'DocumentParagraph':
          self.renderParagraph(container['content'])
       elif containerType == 'DocumentTable':
@@ -740,6 +750,11 @@ class Renderer(object):
       old_cw = self.changeCharProperty(CharProp.Weight, BOLD)
       self.render(text)
       self.changeCharProperty(CharProp.Weight, old_cw)
+
+   def insertItalicFace(self, text):
+      old_cw = self.changeCharProperty(CharProp.Posture, ITALIC)
+      self.render(text)
+      self.changeCharProperty(CharProp.Posture, old_cw)
 
    def insertSourceCode(self, text):
       self.insert_paragraph_character(avoid_empty_paragraph=True)

--- a/markupParser/Text/Udoc/DocumentParser.hs
+++ b/markupParser/Text/Udoc/DocumentParser.hs
@@ -395,6 +395,9 @@ handleExtendedCommand name args handleSpecialCommand =
                      bold <- containerContentsUntil (extendedCommandName "/b") 
                                                     handleSpecialCommand
                      return $ ItemDocumentContainer $ DocumentBoldFace bold
+      "i"      -> do skipEmptyLines
+                     italic <- containerContentsUntil (extendedCommandName "/i") handleSpecialCommand
+                     return $ ItemDocumentContainer $ DocumentItalicFace italic
       "br"     -> return $ ItemLinebreak
       "meta"   -> return $ ItemMetaTag args
       "pb"     -> return $ ItemMetaTag [("type", "pagebreak")]


### PR DESCRIPTION
This allows to format text content with an italic slant:

* Document.hs
  - Introduce DocumentItalicFace as new container type including the
    required introduction into methods like `showJSON` or
   `extractWords`.

* DocumentParser.hs
  - Introduce `i` as new container tag name.

* Renderer.py
  - Add a handler for `DocumentItalicFace` container. This handler
    sets the `CharPosture` attribute of the cursor to italic until
    the whole content of the container is renderer.