### PR TITLE
[Parser|Renderer] Introduce new image tag features

### DIFF
--- a/OpenOfficeIntegration/Renderer/Renderer.py
+++ b/OpenOfficeIntegration/Renderer/Renderer.py
@@ -24,6 +24,7 @@ from com.sun.star.text.ReferenceFieldPart import CHAPTER, CATEGORY_AND_NUMBER
 from com.sun.star.text.ReferenceFieldSource import BOOKMARK, REFERENCE_MARK, SEQUENCE_FIELD
 from com.sun.star.text.SetVariableType import SEQUENCE
 from com.sun.star.text.WrapTextMode import NONE, DYNAMIC, PARALLEL, LEFT, RIGHT
+from com.sun.star.style.ParagraphAdjust import CENTER, LEFT
 
 # ---------------------------------------------------------
 # Setup hacks ...
@@ -526,6 +527,9 @@ class Renderer(object):
       CAPTION_TITLE=self.i18n['figure']
       field = self.createSequenceField(CAPTION_TITLE)
 
+      if alignment == "center":
+          self.insert_paragraph_character(avoid_empty_paragraph=True)
+
       # create a frame to group image and caption
       frame = self._document.createInstance("com.sun.star.text.TextFrame")
       self._document.Text.insertTextContent(self._cursor, frame, False)
@@ -564,13 +568,18 @@ class Renderer(object):
       frame.VertOrient = graph.VertOrient
       frame.VertOrientPosition = graph.VertOrientPosition
 
-      if alignment == "center":
-          frame.AnchorType = AS_CHARACTER
-
       border_line = frame.getPropertyValue("LeftBorder")
       border_line.OuterLineWidth = 0
       border_line.LineWidth = 0
       frame.setPropertyValue("LineStyle", border_line)
+
+      if alignment == "center":
+          frame.AnchorType = AS_CHARACTER
+
+          previous_adjustment = self._cursor.ParaAdjust
+          self._cursor.ParaAdjust = CENTER
+          self.insert_paragraph_character(avoid_empty_paragraph=False)
+          self._cursor.ParaAdjust = previous_adjustment
 
       # Remember the number of the current image, so that we'll later
       # be able to reference it properly.

--- a/OpenOfficeIntegration/Renderer/Renderer.py
+++ b/OpenOfficeIntegration/Renderer/Renderer.py
@@ -538,7 +538,6 @@ class Renderer(object):
       self._cursor = cursor_in_frame
       self._document = frame
 
-      self.insert_paragraph_character(avoid_empty_paragraph=True)
       graph = self._insertImage(path, scale=scaling, align=alignment)
 
       cursor_in_frame.ParaStyleName = self.STYLE_FIGURE_CAPTION
@@ -564,6 +563,9 @@ class Renderer(object):
       frame.HoriOrientPosition = graph.HoriOrientPosition
       frame.VertOrient = graph.VertOrient
       frame.VertOrientPosition = graph.VertOrientPosition
+
+      if alignment == "center":
+          frame.AnchorType = AS_CHARACTER
 
       border_line = frame.getPropertyValue("LeftBorder")
       border_line.OuterLineWidth = 0

--- a/OpenOfficeIntegration/Renderer/Renderer.py
+++ b/OpenOfficeIntegration/Renderer/Renderer.py
@@ -24,7 +24,7 @@ from com.sun.star.text.ReferenceFieldPart import CHAPTER, CATEGORY_AND_NUMBER
 from com.sun.star.text.ReferenceFieldSource import BOOKMARK, REFERENCE_MARK, SEQUENCE_FIELD
 from com.sun.star.text.SetVariableType import SEQUENCE
 from com.sun.star.text.WrapTextMode import NONE, DYNAMIC, PARALLEL, LEFT, RIGHT
-from com.sun.star.style.ParagraphAdjust import CENTER, LEFT
+from com.sun.star.style.ParagraphAdjust import CENTER
 
 # ---------------------------------------------------------
 # Setup hacks ...

--- a/OpenOfficeIntegration/Renderer/Renderer.py
+++ b/OpenOfficeIntegration/Renderer/Renderer.py
@@ -700,7 +700,7 @@ class Renderer(object):
       self.toc = index
 
    def insertPageBreak(self):
-      self.insert_paragraph_character(avoid_empty_paragraph=True)
+      self.insert_paragraph_character(avoid_empty_paragraph=False)
       self._cursor.gotoEnd(False)
       self._cursor.BreakType = PAGE_BEFORE
 

--- a/OpenOfficeIntegration/Renderer/Renderer.py
+++ b/OpenOfficeIntegration/Renderer/Renderer.py
@@ -409,7 +409,7 @@ class Renderer(object):
       maxHeight = (self.template_height() - 20) * 100  # Template maximum height in millimeters is 236.
                                                        # Let's save some margin.
 
-      size = image.Size
+      size = image.ActualSize
       if size.Height == 0 or size.Width == 0:
          size.Height = image.SizePixel.Height * 2540.0 * TwipsPerPixelY() / 1440
          size.Width  = image.SizePixel.Width  * 2540.0 * TwipsPerPixelX() / 1440

--- a/markupParser/Text/Udoc/Document.hs
+++ b/markupParser/Text/Udoc/Document.hs
@@ -244,28 +244,31 @@ instance JSON Heading where
 
 {-| An image in a document -}
 data DocumentImage = Image {
-                        imageFilename :: String -- ^ The file name of the image
-                      , imageCaption  :: String -- ^ The image's caption
-                      , imageLabel    :: String -- ^ A label for referencing the image
-                      , imageScaling  :: String -- ^ An expected scaling factor.
+                        imageFilename  :: String -- ^ The file name of the image
+                      , imageCaption   :: String -- ^ The image's caption
+                      , imageLabel     :: String -- ^ A label for referencing the image
+                      , imageScaling   :: String -- ^ An expected scaling factor (Default: 1.0)
+                      , imageAlignment :: String -- ^ The alignment (Default: center)
                      } deriving(Show, Eq)
 
 instance JSON DocumentImage where
-   showJSON (Image filename caption label scaling) =
-      makeObj [  ("imageFilename", showJSON filename)
-               , ("imageCaption" , showJSON caption)
-               , ("imageLabel"   , showJSON label)
-               , ("imageScaling" , showJSON scaling)
+   showJSON (Image filename caption label scaling alignment) =
+      makeObj [  ("imageFilename" , showJSON filename)
+               , ("imageCaption"  , showJSON caption)
+               , ("imageLabel"    , showJSON label)
+               , ("imageScaling"  , showJSON scaling)
+               , ("imageAlignment", showJSON alignment)
               ]
 
    readJSON (JSObject obj) = let
       jsonObjAssoc = fromJSObject obj
     in do
-      filename <- mLookup "imageFilename" jsonObjAssoc >>= readJSON
-      caption  <- mLookup "imageCaption"  jsonObjAssoc >>= readJSON
-      label    <- mLookup "imageLabel"    jsonObjAssoc >>= readJSON
-      scaling  <- mLookup "imageScaling"       jsonObjAssoc >>= readJSON
-      return $ Image filename caption label scaling
+      filename  <- mLookup "imageFilename"  jsonObjAssoc >>= readJSON
+      caption   <- mLookup "imageCaption"   jsonObjAssoc >>= readJSON
+      label     <- mLookup "imageLabel"     jsonObjAssoc >>= readJSON
+      scaling   <- mLookup "imageScaling"   jsonObjAssoc >>= readJSON
+      alignment <- mLookup "imageAlignment" jsonObjAssoc >>= readJSON
+      return $ Image filename caption label scaling alignment
 
 ------------------------ Compute the heading level --------------------
 

--- a/markupParser/Text/Udoc/Document.hs
+++ b/markupParser/Text/Udoc/Document.hs
@@ -246,15 +246,16 @@ instance JSON Heading where
 data DocumentImage = Image {
                         imageFilename :: String -- ^ The file name of the image
                       , imageCaption  :: String -- ^ The image's caption
-                      , imageLabel    :: String -- ^ A label for referencing the
-                                                -- image
+                      , imageLabel    :: String -- ^ A label for referencing the image
+                      , imageScaling  :: String -- ^ An expected scaling factor.
                      } deriving(Show, Eq)
 
 instance JSON DocumentImage where
-   showJSON (Image filename caption label) =
+   showJSON (Image filename caption label scaling) =
       makeObj [  ("imageFilename", showJSON filename)
                , ("imageCaption" , showJSON caption)
                , ("imageLabel"   , showJSON label)
+               , ("imageScaling" , showJSON scaling)
               ]
 
    readJSON (JSObject obj) = let
@@ -263,7 +264,8 @@ instance JSON DocumentImage where
       filename <- mLookup "imageFilename" jsonObjAssoc >>= readJSON
       caption  <- mLookup "imageCaption"  jsonObjAssoc >>= readJSON
       label    <- mLookup "imageLabel"    jsonObjAssoc >>= readJSON
-      return $ Image filename caption label
+      scaling  <- mLookup "imageScaling"       jsonObjAssoc >>= readJSON
+      return $ Image filename caption label scaling
 
 ------------------------ Compute the heading level --------------------
 

--- a/markupParser/Text/Udoc/DocumentParser.hs
+++ b/markupParser/Text/Udoc/DocumentParser.hs
@@ -276,6 +276,10 @@ getArgumentsOrFail mandArgs optArgs aList f =
                         " but only got " ++ (show $ map fst aList)
       Just m'  -> return $ f m' opt
 
+{-| Lookup a required tag attribute that may not exist. -}
+mLookup :: (Show a, Monad m, Eq a) => a -> [(a , b)] -> String -> m b
+mLookup k al error_message = maybe (fail error_message) return $ lookup k al
+
 -- | Creates an ItemMetaTag from the following data: a tag name, the list
 -- of mandatory properties and the list of optional properties.
 createMetaTag ::    String -- ^ The name of the tag type
@@ -398,15 +402,22 @@ handleExtendedCommand name args handleSpecialCommand =
       "br"     -> return $ ItemLinebreak
       "meta"   -> return $ ItemMetaTag args
       "pb"     -> return $ ItemMetaTag [("type", "pagebreak")]
-      "image"  -> do label   <- mlookup "label"   args "Missing label in image tag"
-                     caption <- mlookup "caption" args "Missing caption in image tag"
-                     path    <- mlookup "path"    args "Missing path in image tag"
+
+      "image"  -> do label   <- mLookup "label"   args "Missing label in image tag"
+                     caption <- mLookup "caption" args "Missing caption in image tag"
+                     path    <- mLookup "path"    args "Missing path in image tag"
                      eatSpaces <- isOptionSet SkipNewlinesAfterImage 
                      when eatSpaces skipEmptyLines 
                      return $ ItemImage $ Image path caption label
-                     where mlookup k a errmsg = case lookup k a of
-                                                   Nothing -> fail errmsg
-                                                   Just val -> return val
+
+      "inlineImage" -> do let vOffset = fromMaybe "0" $ lookup "vOffset" args
+                          path <- mLookup "path" args "Missing path in inlineImage tag"
+                          return $ ItemMetaTag (
+                            [ ("type", "inlineImage")
+                            , ("path", path)
+                            , ("vOffset", vOffset)
+                            ])
+
       "table"  -> do let mCL = ((,)) <$> lookup "caption" args <*> lookup "label" args
                      let style = fromMaybe "head_top" $ lookup "style" args
                      let mWidths = sequence $ map readMaybe $ map (filter (/= ' ')) $ split ',' $ fromMaybe "" $ lookup "widths" args

--- a/markupParser/Text/Udoc/DocumentParser.hs
+++ b/markupParser/Text/Udoc/DocumentParser.hs
@@ -404,12 +404,13 @@ handleExtendedCommand name args handleSpecialCommand =
       "pb"     -> return $ ItemMetaTag [("type", "pagebreak")]
 
       "image"  -> do let scaling = fromMaybe "1" $ lookup "scaling" args
+                         alignment = fromMaybe "center" $ lookup "align" args
                      label   <- mLookup "label"   args "Missing label in image tag"
                      caption <- mLookup "caption" args "Missing caption in image tag"
                      path    <- mLookup "path"    args "Missing path in image tag"
                      eatSpaces <- isOptionSet SkipNewlinesAfterImage
                      when eatSpaces skipEmptyLines 
-                     return $ ItemImage $ Image path caption label scaling
+                     return $ ItemImage $ Image path caption label scaling alignment
 
       "inlineImage" -> do let vOffset = fromMaybe "0" $ lookup "vOffset" args
                           path <- mLookup "path" args "Missing path in inlineImage tag"

--- a/markupParser/Text/Udoc/DocumentParser.hs
+++ b/markupParser/Text/Udoc/DocumentParser.hs
@@ -403,12 +403,13 @@ handleExtendedCommand name args handleSpecialCommand =
       "meta"   -> return $ ItemMetaTag args
       "pb"     -> return $ ItemMetaTag [("type", "pagebreak")]
 
-      "image"  -> do label   <- mLookup "label"   args "Missing label in image tag"
+      "image"  -> do let scaling = fromMaybe "1" $ lookup "scaling" args
+                     label   <- mLookup "label"   args "Missing label in image tag"
                      caption <- mLookup "caption" args "Missing caption in image tag"
                      path    <- mLookup "path"    args "Missing path in image tag"
-                     eatSpaces <- isOptionSet SkipNewlinesAfterImage 
+                     eatSpaces <- isOptionSet SkipNewlinesAfterImage
                      when eatSpaces skipEmptyLines 
-                     return $ ItemImage $ Image path caption label
+                     return $ ItemImage $ Image path caption label scaling
 
       "inlineImage" -> do let vOffset = fromMaybe "0" $ lookup "vOffset" args
                           path <- mLookup "path" args "Missing path in inlineImage tag"


### PR DESCRIPTION
#### `[inlineImage]`
Add the missing parsing logic for `[inlineImage path = "...", vOffset = ...]`. The renderer already supported it so no further changes on this side.

#### [`image`]
Multiple Changes here:

 - Add `scaling` as new image attribute (Default: `1.0`).
   Scaling is applied after size guessing so that any image with a missing scaling factor will not change its size.

 - Add `align` as a new image attribute (Default: `center`)
   Supported values:
     - `center`: Image is centered and no text wrapping occurrences. This should match current behavior
     - `left`: Image is left aligned and text wrapping to the right is enabled.
     - `right`: Image is right aligned and text wrapping to the left is enabled.

 - Wrap image and caption in a frame to ensure that captions are always placed below the image. Side effect: Captions are now always as wide as the image itself, so it might come to strange effects if the image is very thin.