### PR TITLE
[Parser] Allow trailing spaces in multiline table delimiters.

### DIFF
--- a/markupParser/Text/Udoc/DocumentParser.hs
+++ b/markupParser/Text/Udoc/DocumentParser.hs
@@ -504,9 +504,10 @@ tableAppend ml l table
    | not ml = (table ++ [l], False)
    | ml && length table > 0 = ((init table) ++ [zipWith (\a b -> a ++ b ++ "\n") (last table) l], True)
    | otherwise = (table, ml) -- Should not happen
-   where isDelimiter (l:[]) = all ((||) <$> (=='-') <*> (=='+')) l
+   where isDelimiter (l:[]) = all ((||) <$> (=='-') <*> (=='+')) (trimEnd l)
          isDelimiter _      = False
          emptyRow = repeat ""
+         trimEnd l = dropWhileEnd isSpace l
 
 -- | Convenience wrapper around our table parsing function
 table :: IParse [[String]]


### PR DESCRIPTION
Fixes rendering issues if a multi line table delimiter contains trailing spaces.