### PR TITLE
[Parser|Renderer] Allow formatted content in headings.

### DIFF
--- a/OpenOfficeIntegration/Renderer/Renderer.py
+++ b/OpenOfficeIntegration/Renderer/Renderer.py
@@ -191,8 +191,7 @@ class Renderer(object):
    def renderContainer(self, container):
       containerType = container['type']
       if containerType == 'DocumentHeading':
-         self.renderHeading(container['DocumentHeading'], 
-                            container['content'])
+         self.renderHeading(container['DocumentHeading'], container['content'])
       elif containerType == 'DocumentBoldFace':
          self.renderBoldFace(container['content'])
       elif containerType == 'DocumentItalicFace':
@@ -202,8 +201,7 @@ class Renderer(object):
       elif containerType == 'DocumentTable':
          self.renderTable(container['content'], container['caption'], container['label'], container['style'], container['widths'])
       elif containerType == 'DocumentMetaContainer':
-         self.renderMetaContainer(container['content'],
-                             container['properties'])
+         self.renderMetaContainer(container['content'], container['properties'])
       elif containerType == 'DocumentUList':
          self.renderUlist(container['content'])
       elif containerType == 'DocumentOList':
@@ -794,13 +792,14 @@ class Renderer(object):
       if headingLevel > 4:
          raise RuntimeError('Illegal heading level!')
 
-      self.render(headingText)
       self._cursor.ParaStyleName = self.STYLE_PARAM_HEADING % headingLevel
-      headingNumber = self._cursor.ListLabelString
 
+      self.render(headingText)
       self.insert_paragraph_character(avoid_empty_paragraph=True)
+
       self._cursor.ParaStyleName = self.STYLE_STANDARD_TEXT
 
+      headingNumber = self._cursor.ListLabelString
       self.CurrentHeading = (headingLevel, headingText, headingNumber)
 
    def insertBoldFace(self, text):

--- a/markupParser/Text/Udoc/DocumentParser.hs
+++ b/markupParser/Text/Udoc/DocumentParser.hs
@@ -827,17 +827,16 @@ headingBegin = do
 
 -- | A heading
 heading :: HSP -> IParse DocumentItem
-heading hsp =
-   let
-      closeHeading :: IParse ()
-      closeHeading = do
-         newline
-         return ()
-   in
-     do
-       level <- headingBegin
-       content <- paragraphWithout closeHeading hsp
-       return $ ItemDocumentContainer $ DocumentHeading (Heading level Nothing) [content]
+heading hsp = do
+    level <- headingBegin
+    content <- many1 (
+             (
+                (do x <- try $ line hsp; return x)
+                <|> (do x <- try $ extendedCommand hsp; return [x])
+             )
+          )
+    skipEmptyLines
+    return $ ItemDocumentContainer $ DocumentHeading (Heading level Nothing) (concat content)
 
 -- | The start of a block quote
 blockQuoteBegin :: IParse ()

--- a/markupParser/Text/Udoc/DocumentParser.hs
+++ b/markupParser/Text/Udoc/DocumentParser.hs
@@ -827,14 +827,17 @@ headingBegin = do
 
 -- | A heading
 heading :: HSP -> IParse DocumentItem
-heading hsp = do level <- headingBegin
-                 items <- block $ do
-                              l <- line hsp
-                              optional newline
-                              spaces
-                              return l
-                 skipEmptyLines
-                 return $ ItemDocumentContainer (DocumentHeading (Heading level Nothing) (concat items))
+heading hsp =
+   let
+      closeHeading :: IParse ()
+      closeHeading = do
+         newline
+         return ()
+   in
+     do
+       level <- headingBegin
+       content <- paragraphWithout closeHeading hsp
+       return $ ItemDocumentContainer $ DocumentHeading (Heading level Nothing) [content]
 
 -- | The start of a block quote
 blockQuoteBegin :: IParse ()


### PR DESCRIPTION
This change set enables the use of different kinds of formatted content in headings.

The main purpose of this change set is to avoid accidental line breaks if an inline quote or reference is used inside a heading.  Secondary it will allow to format parts of the heading as bold or italic.