### PR TITLE
[Renderer] Always set 'STYLE_STANDARD_TEXT' as initial paragraph style.

### DIFF
--- a/OpenOfficeIntegration/Renderer/Renderer.py
+++ b/OpenOfficeIntegration/Renderer/Renderer.py
@@ -68,6 +68,8 @@ class Renderer(object):
       self._document = document
       self._realDocument = document
 
+      self._cursor.ParaStyleName = self.STYLE_STANDARD_TEXT
+
    def handleCustomMetaContainer(self, properties, content):
       raise NotImplementedError
 


### PR DESCRIPTION
Ensures to set use the `Standard Text` style for any paragraph even if no initial heading is present.