### PR TITLE
[Renderer] Remove redundant space in inline quotes.

### DIFF
--- a/OpenOfficeIntegration/Renderer/Renderer.py
+++ b/OpenOfficeIntegration/Renderer/Renderer.py
@@ -898,7 +898,7 @@ class Renderer(object):
       self.insert_paragraph_character(avoid_empty_paragraph=True)
       self.changeParaStyle(oldStyle)
 
-   def insertInlineQuote(self, text):
+   def insertInlineQuote(self, content):
       if self.needSpace():
          self.insertString(" ")
 
@@ -906,12 +906,17 @@ class Renderer(object):
          self.insertString('„')
       else: 
          self.insertString('"')
-      self.render(text)
-      self.smartSpace()
+
+      # Do not put a space in front of quoted content.
+      self._lastItem = None
+      self.render(content)
+
       if self._currentLanguage == 'de':
          self.insertString('“')
       else:
          self.insertString('"')
+
+      self.smartSpace()
 
    def insertInlineSourceCode(self, text):
       if self.needSpace():


### PR DESCRIPTION
Delete the internal state storing the last known item during the
initialization of an inline quote to avoid a redundant space if
the first element inside the inline quotation container is not
a simple word but some kind of content creation tag.

This is necessary as the inline quote works like a container and
therefore the renderer still references the last element in front
of the inline quote instead of the container itself.

If the first child element relies on `needSpace()` to determine
if an additional space should be injected it would still base this
decision on the previous element, even if the handler itself already
injected a quotation mark into the text.