### PR TITLE
[Renderer] Remove trailing empty lines in tables.

### DIFF
--- a/OpenOfficeIntegration/Renderer/Renderer.py
+++ b/OpenOfficeIntegration/Renderer/Renderer.py
@@ -825,6 +825,12 @@ class Renderer(object):
 
             self.render(cellContent)
 
+            # If a table cell ends in an empty paragraph try to remove the
+            # leading paragraph break to avoid the unnecessary empty line.
+            if self._cursor.isStartOfParagraph():
+                self._cursor.goLeft(1, True)
+                self._cursor.setString("")
+
             self._document = oldDoc
             self._cursor = oldCur
    


### PR DESCRIPTION
Sometimes a table cell accidentally ends with an empty paragraph, e.g. if the cell contains an ordered or unordered list. To avoid those lines a new check got integrated which tries to identity trailing empty paragraphs in table cells and removes them.