### PR TITLE
Fix: Rendere Stuck On Image Placement

### DIFF
--- a/OpenOfficeIntegration/Renderer/Renderer.py
+++ b/OpenOfficeIntegration/Renderer/Renderer.py
@@ -478,6 +478,7 @@ class Renderer(object):
       # Now insert the image, *NOT* using the source from the internal
       # bitmap table, but instead using the external URL.
       graph = self._realDocument.createInstance("com.sun.star.text.TextGraphicObject")
+      graph.AnchorType = AS_CHARACTER
 
       if align == "left":
          graph.HoriOrient = 0
@@ -488,9 +489,6 @@ class Renderer(object):
          graph.HoriOrient = 1
          graph.LeftMargin = 300
          graph.TextWrap = LEFT
-
-      if inline:
-         graph.AnchorType = AS_CHARACTER
 
       self._document.Text.insertTextContent(self._cursor, graph, False)
 

--- a/OpenOfficeIntegration/Renderer/Renderer.py
+++ b/OpenOfficeIntegration/Renderer/Renderer.py
@@ -578,6 +578,12 @@ class Renderer(object):
           frame.TextWrap = LEFT
           frame.Surround = LEFT
       elif alignment == "center":
+          # Before changing the order of the following commands please ensure
+          # that the order of multiple images is ensured. E.g if two half page
+          # sized images are followed by a full page sized image.
+          frame.TextWrap = NONE
+          frame.Surround = NONE
+          frame.AllowOverlap = False
           frame.AnchorType = AS_CHARACTER
 
           previous_adjustment = self._cursor.ParaAdjust

--- a/OpenOfficeIntegration/Renderer/Renderer.py
+++ b/OpenOfficeIntegration/Renderer/Renderer.py
@@ -480,6 +480,8 @@ class Renderer(object):
       graph = self._realDocument.createInstance("com.sun.star.text.TextGraphicObject")
       graph.AnchorType = AS_CHARACTER
 
+      border_line_style = uno.createUnoStruct("com.sun.star.table.BorderLine2")
+      graph.setPropertyValue("LineStyle", border_line_style)
       if align == "left":
          graph.HoriOrient = 0
          graph.RightMargin = 300
@@ -580,10 +582,8 @@ class Renderer(object):
       frame.VertOrient = graph.VertOrient
       frame.VertOrientPosition = graph.VertOrientPosition
 
-      border_line = frame.getPropertyValue("LeftBorder")
-      border_line.OuterLineWidth = 0
-      border_line.LineWidth = 0
-      frame.setPropertyValue("LineStyle", border_line)
+      border_line_style = uno.createUnoStruct("com.sun.star.table.BorderLine2")
+      frame.setPropertyValue("LineStyle", border_line_style)
 
       if alignment == "center":
           frame.AnchorType = AS_CHARACTER


### PR DESCRIPTION
The renderer sometimes stuck if it encounters consecutive images, especially if those span multiple pages and multiple of them potentially fit onto the same page.

It seems like this is mostly a problem related to the anchoring and orientation behavior handling. This has been fixed in that the whole related handling got moved to the surrounding frame instead of the inner image element. 