### PR TITLE
[Draft][Renderer] Abort if input contains non-printable characters.

### DIFF
--- a/OpenOfficeIntegration/Renderer/Renderer.py
+++ b/OpenOfficeIntegration/Renderer/Renderer.py
@@ -649,7 +649,23 @@ class Renderer(object):
       self.render(content)
 
    def insertString(self, text):
-      self._document.Text.insertString(self._cursor, text, False)
+       if any(not (c.isprintable() or c.isspace()) for c in text):
+           encoded_text = ''.join([
+               char if (char.isprintable() or char.isspace()) else ''.join([
+                   f'\\x{byte.encode("UTF-8").hex()}'
+                   for byte in char
+               ])
+               for char in text
+           ])
+
+           raise RuntimeError(
+               "The following text snippet contains unprintable characters!\n\n"
+               f"{text}\n\n"
+               "A Solution might be to replace those characters with hex sequences, e.g.:\n\n"
+               f"{encoded_text}\n"
+           )
+
+       self._document.Text.insertString(self._cursor, text, False)
 
    def insertFootnote(self, content):
       fn = self._realDocument.createInstance("com.sun.star.text.Footnote")


### PR DESCRIPTION
Denies to render any strings, which include non-printable characters, as the underlying LibreOffice renderer wouldn't be able to include those properly into the final document.

This is a render based solution, which detects those strings right before they get inserted into the final document. Therefore the error message contains the final string including some context, but  doesn't contain any hints on the filename or location of the broken strings. 

Alternative solution to #45