### PR TITLE
Allow `s` and `'s` after inline formatting.

### DIFF
--- a/OpenOfficeIntegration/Renderer/Renderer.py
+++ b/OpenOfficeIntegration/Renderer/Renderer.py
@@ -948,7 +948,7 @@ class Renderer(object):
 
       old_properties = self.changeCharProperty(CharProp.StyleName, self.STYLE_INLINE_SOURCE_CODE)
       self.render(text)
-      self.smartSpace(skip_if=lambda cursor, word: word == "s" or cursor.isStartOfParagraph())
+      self.smartSpace(skip_if=lambda cursor, word: word in ["s", "'s"] or cursor.isStartOfParagraph())
       self.restorePropertySet(old_properties)
 
    def insertParagraph(self, text):

--- a/OpenOfficeIntegration/Renderer/Renderer.py
+++ b/OpenOfficeIntegration/Renderer/Renderer.py
@@ -121,7 +121,7 @@ class Renderer(object):
          self.insertString(' ')
 
       self.insertItalicFace(items)
-      self.smartSpace()
+      self.smartSpace(skip_if=lambda cursor, word: word in ["s", "'s"] or cursor.isStartOfParagraph())
 
    def renderParagraph(self, items):
       self.insertParagraph(items)

--- a/OpenOfficeIntegration/Renderer/Renderer.py
+++ b/OpenOfficeIntegration/Renderer/Renderer.py
@@ -112,9 +112,11 @@ class Renderer(object):
    def renderBoldFace(self, items):
       if self.needSpace() and not self._inSource:
          self.insertString(' ')
+
       self.insertBoldFace(items)
+
       if not self._inSource:
-          self.smartSpace()
+         self.smartSpace(skip_if=lambda cursor, word: word in ["s", "'s"] or cursor.isStartOfParagraph())
 
    def renderItalicFace(self, items):
       if self.needSpace():


### PR DESCRIPTION
Allows to put `s` and `'s` after any kind of inline formatting (source, italic, bold) without an intermediate space.