### PR TITLE
[Renderer] Don't restore unchanged properties. 

### DIFF
--- a/OpenOfficeIntegration/Renderer/Renderer.py
+++ b/OpenOfficeIntegration/Renderer/Renderer.py
@@ -872,7 +872,7 @@ class Renderer(object):
          self.insertString(caption)
 
          self.insert_paragraph_character(avoid_empty_paragraph=True)
-         self.changeParaStyle(oldStyle)
+         self.restorePropertySet(oldStyle)
 
          # Remember the number of the current table so that later we'll
          # be able to reference it properly.

--- a/OpenOfficeIntegration/Renderer/Renderer.py
+++ b/OpenOfficeIntegration/Renderer/Renderer.py
@@ -382,6 +382,9 @@ class Renderer(object):
 
    def restorePropertySet(self, properties):
       for (name, value) in properties:
+         if self._cursor.getPropertyValue(name) == value:
+             continue
+
          if value in [None, "", (), []] \
             or (name in ["ParaAutoStyleName", "CharAutoStyleName"] and value == "0"):
 


### PR DESCRIPTION
Should fix a regression which prevents proper heading formatting, e.g. after inline source elements.

Seems like this regression is related to one of the properties we restore to default but didn't change in the first place. Therefore, LibreOffice starts to assume that there is already a custom text style applied which sometimes prevent the usage of other Fonts.