### PR TITLE
[Renderer] Enforce at least one space after `+` to start an olist item.

### DIFF
--- a/markupParser/Text/Udoc/DocumentParser.hs
+++ b/markupParser/Text/Udoc/DocumentParser.hs
@@ -778,7 +778,7 @@ newOlistItemBegin :: IParse (Int, String)
 newOlistItemBegin = do
    i <- many $ char ' '
    string "+"
-   spaces
+   many1 space
    return ((length i), "0")
 
 -- | The old version of ordered lists start with dotted numbers followed


### PR DESCRIPTION
Previously the parser interpreated everything after a leading `+` as content of the olist item. This resulted in cases where an international phone number got recognized as new olist item.

This should now be fixed.