### PR TITLE
Support LO 7.2 style sheet names

### DIFF
--- a/OpenOfficeIntegration/Renderer/Renderer.py
+++ b/OpenOfficeIntegration/Renderer/Renderer.py
@@ -73,7 +73,11 @@ class Renderer(object):
       try:
            self._cursor.CharStyleName = "Default Character Style"
       except:
+           pass
+      try:
            self._cursor.CharStyleName = "Default Style"
+      except:
+           self._cursor.CharStyleName = "No Character Style"
 
    def handleCustomMetaContainer(self, properties, content):
       raise NotImplementedError


### PR DESCRIPTION
Upstream changed "Default Character Style" to "No Character Style" in
https://git.libreoffice.org/core/+/b2b99a4ce105e1c1627e923f2fc4e9bf488dff2b%5E%21
which led to a runtime exception triggered by
https://github.com/LibreOffice/core/blob/libreoffice-7-2-2/sw/source/core/unocore/unoobj.cxx#L197